### PR TITLE
Modify userdata for parameter store

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create ECS cluster with EC2 autoscaling
 
 Datadog API Key in AWS Parameter Store.
 
-Do ensure that 'dd_api_key' is available in Parameter Store as a SecureString.
+Do ensure that '/$env/datadog/api-key' is available in Parameter Store as a SecureString.
 
 The command to retrieve the API key from Parameter Store is embedded inside user-data.sh. It will be executed during system init, make an AWS call to SSM to fetch the value in plain text.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 
 Create ECS cluster with EC2 autoscaling
 
+
+## Dependencies
+
+Datadog API Key in AWS Parameter Store.
+
+Do ensure that 'dd_api_key' is available in Parameter Store as a SecureString.
+
+The command to retrieve the API key from Parameter Store is embedded inside user-data.sh. It will be executed during system init, make an AWS call to SSM to fetch the value in plain text.
+
 ## Run with terraform
 
 Update necessary variables and settings in terraform.tfvars following the sample file.

--- a/user-data.sh
+++ b/user-data.sh
@@ -29,7 +29,7 @@ aws ecs start-task --cluster "$${cluster}" --task-definition $${datadog_task} --
 
 #run SSM command to retrieve parameters
 
-dd_api_key=$${aws ssm get-parameters --names dd_api_key --with-decryption --query 'Parameters[*].Value' --output text}
+dd_api_key=$(aws ssm get-parameters --names dd_api_key --with-decryption --query 'Parameters[*].Value' --output text)
 
 if [ -n "$dd_api_key" ]; then
     DD_API_KEY="$dd_api_key" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"

--- a/user-data.sh
+++ b/user-data.sh
@@ -28,8 +28,8 @@ aws ecs start-task --cluster "$${cluster}" --task-definition $${datadog_task} --
 
 
 #run SSM command to retrieve parameters
-
-dd_api_key=$(aws ssm get-parameters --names dd_api_key --with-decryption --query 'Parameters[*].Value' --output text --region $region)
+dd_parameter_api_name="/${env}/datadog/api-key"
+dd_api_key=$(aws ssm get-parameters --names $dd_parameter_api_name --with-decryption --query 'Parameters[*].Value' --output text --region $region)
 
 if [ -n "$dd_api_key" ]; then
     DD_API_KEY="$dd_api_key" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"

--- a/user-data.sh
+++ b/user-data.sh
@@ -26,6 +26,11 @@ datadog_task="dd-agent-task"
 aws ecs start-task --cluster "$${cluster}" --task-definition $${scalyr_task} --container-instances $${instance_arn} --region $region
 aws ecs start-task --cluster "$${cluster}" --task-definition $${datadog_task} --container-instances $${instance_arn} --region $region
 
-if [ -n "${dd_api_key}" ]; then
-    DD_API_KEY="${dd_api_key}" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"
+
+#run SSM command to retrieve parameters
+
+dd_api_key=$${aws ssm get-parameters --names dd_api_key --with-decryption --query 'Parameters[*].Value' --output text}
+
+if [ -n "$dd_api_key" ]; then
+    DD_API_KEY="$dd_api_key" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"
 fi

--- a/user-data.sh
+++ b/user-data.sh
@@ -29,7 +29,7 @@ aws ecs start-task --cluster "$${cluster}" --task-definition $${datadog_task} --
 
 #run SSM command to retrieve parameters
 
-dd_api_key=$(aws ssm get-parameters --names dd_api_key --with-decryption --query 'Parameters[*].Value' --output text)
+dd_api_key=$(aws ssm get-parameters --names dd_api_key --with-decryption --query 'Parameters[*].Value' --output text --region $region)
 
 if [ -n "$dd_api_key" ]; then
     DD_API_KEY="$dd_api_key" bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"


### PR DESCRIPTION
Update 
- Remove Datadog API key from user-data.sh
- Update user-data.sh with SSM CLI to fetch Datadog API key from parameter store

Dependencies
- IAM Role of EC2 needs to have permission to make SSM call
- Datadog variable defined and stored in the parameter store