### PR TITLE
Add variable disk space based on CPU size on Spot IO

### DIFF
--- a/spotinst.tf
+++ b/spotinst.tf
@@ -26,6 +26,21 @@ resource "spotinst_ocean_ecs" "spotinst_auto_scaling" {
   iam_instance_profile = "${data.aws_iam_instance_profile.ecs.arn}"
   monitoring           = true                                          # Detailed monitoring
 
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = "true"
+      encrypted = "false"
+      volume_type = "${var.root_ebs_type}"
+      volume_size = "${var.root_ebs_size}"
+      dynamic_volume_size {
+        base_size = "${var.root_ebs_size}"
+        resource = "CPU"
+        size_per_resource_unit = 5
+      }
+    }
+  }
+
   autoscaler {
     is_auto_config = true
     is_enabled     = true


### PR DESCRIPTION
This will ensure that the disk space is dynamic based on CPU size on Spot IO.
Currently all types of instances get the same default disk space - 30GB. The ebs disk size variable was not being used in the Spot launch config.

When a very large instance is provisioned the number of tasks on it are high and the disk space is not sufficient.
This will ensure the disk size scales based on instance.